### PR TITLE
Fix nimble install

### DIFF
--- a/build.nims
+++ b/build.nims
@@ -1,7 +1,5 @@
 import std / [os, strutils, sequtils]
 
-switch("define", "libp2p_pki_schemes=secp256k1")
-
 task testAll, "Run DHT tests":
   exec "nim c -r tests/testAll.nim"
 

--- a/codexdht.nimble
+++ b/codexdht.nimble
@@ -23,4 +23,4 @@ requires "asynctest >= 0.3.1 & < 0.4.0"
 requires "https://github.com/status-im/nim-datastore#head"
 requires "questionable"
 
-import "build.nims"
+include "build.nims"

--- a/codexdht.nimble
+++ b/codexdht.nimble
@@ -2,10 +2,10 @@
 
 version       = "0.3.2"
 author        = "Status Research & Development GmbH"
-description   = "DHT based on the libp2p Kademlia spec"
+description   = "DHT based on Eth discv5 implementation"
 license       = "MIT"
 skipDirs      = @["tests"]
-
+installFiles  = @["build.nims"]
 
 # Dependencies
 requires "nim >= 1.2.0"
@@ -23,6 +23,4 @@ requires "asynctest >= 0.3.1 & < 0.4.0"
 requires "https://github.com/status-im/nim-datastore#head"
 requires "questionable"
 
-include "build.nims"
-
-
+import "build.nims"

--- a/codexdht/private/eth/p2p/discoveryv5/encoding.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/encoding.nim
@@ -307,7 +307,7 @@ proc encodeHandshakePacket*(rng: var HmacDrbgContext, c: var Codec,
 
   authdataHead.add(c.localNode.id.toByteArrayBE())
 
-  let ephKeys = ? KeyPair.random(rng)
+  let ephKeys = ? KeyPair.random(PKScheme.Secp256k1, rng)
                     .mapErr((e: CryptoError) =>
                       ("Failed to create random key pair: " & $e).cstring)
 

--- a/config.nims
+++ b/config.nims
@@ -1,4 +1,6 @@
 
+switch("define", "libp2p_pki_schemes=secp256k1")
+
 include "build.nims"
 
 # begin Nimble config (version 2)

--- a/tests/dht/test_helper.nim
+++ b/tests/dht/test_helper.nim
@@ -14,7 +14,7 @@ proc localAddress*(port: int): Address =
   Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(port))
 
 proc example*(T: type PrivateKey, rng: ref HmacDrbgContext): PrivateKey =
-  PrivateKey.random(rng[]).expect("Valid rng for private key")
+  PrivateKey.random(PKScheme.Secp256k1, rng[]).expect("Valid rng for private key")
 
 proc example*(T: type NodeId, rng: ref HmacDrbgContext): NodeId =
   let

--- a/tests/dht/test_providers.nim
+++ b/tests/dht/test_providers.nim
@@ -125,7 +125,6 @@ suite "Providers Tests: node alone":
     debug "Providers:", providers
     check (providers.len == 0)
 
-
 suite "Providers Tests: two nodes":
 
   var

--- a/tests/testAllParallel.nim
+++ b/tests/testAllParallel.nim
@@ -8,13 +8,13 @@ var cmds: seq[string]
 
 when defined(testsPart1) or defined(testsAll):
   cmds.add [
-    "nim c -r tests/dht/test_providers.nim",
-    "nim c -r tests/dht/test_providermngr.nim",
+    "nim c -r --hints:off --verbosity:0 tests/dht/test_providers.nim",
+    "nim c -r --hints:off --verbosity:0 tests/dht/test_providermngr.nim",
   ]
 when defined(testsPart2) or defined(testsAll):
   cmds.add [
-    "nim c -r tests/discv5/test_discoveryv5.nim",
-    "nim c -r tests/discv5/test_discoveryv5_encoding.nim",
+    "nim c -r --hints:off --verbosity:0 tests/discv5/test_discoveryv5.nim",
+    "nim c -r --hints:off --verbosity:0 tests/discv5/test_discoveryv5_encoding.nim",
   ]
 
 echo "Running Test Commands: ", cmds


### PR DESCRIPTION
Running `nimble install` without `-d` fails unless the `build.nims` file gets copied along the rest of the package files.