### PR TITLE
Fix: queue messages when there is no encryption key

### DIFF
--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -206,8 +206,6 @@ proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
           node.seen = true
           if t.client.addNode(node):
             trace "Added new node to routing table after handshake", node, tablesize=t.client.nodesDiscovered()
-          # handshake finished, TODO: should this be inside the if above?
-          t.keyexchangeInProgress.excl(node.id)
           discard t.sendPending(node)
   else:
     trace "Packet decoding error", myport = t.bindAddress.port, error = decoded.error, address = a

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -95,12 +95,15 @@ proc sendWhoareyou(t: Transport, toId: NodeId, a: Address,
     sleepAsync(handshakeTimeout).addCallback() do(data: pointer):
     # TODO: should we still provide cancellation in case handshake completes
     # correctly?
-      t.codec.handshakes.del(key)
+      if t.codec.hasHandshake(key):
+        debug "Handshake timeout", myport = t.bindAddress.port , dstId = toId, address = a
+        t.codec.handshakes.del(key)
 
     trace "Send whoareyou", dstId = toId, address = a
     t.sendToA(a, data)
   else:
-    debug "Node with this id already has ongoing handshake, ignoring packet"
+    # TODO: is this reasonable to drop it? Should we allow a mini-queue here?
+    debug "Node with this id already has ongoing handshake, ignoring packet", myport = t.bindAddress.port , dstId = toId, address = a
 
 proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
   let decoded = t.codec.decodePacket(a, packet)

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -55,7 +55,7 @@ proc send(t: Transport, n: Node, data: seq[byte]) =
   t.sendToA(n.address.get(), data)
 
 proc sendMessage*(t: Transport, toId: NodeId, toAddr: Address, message: seq[byte]) =
-  let (data, _) = encodeMessagePacket(t.rng[], t.codec, toId, toAddr,
+  let (data, _, _) = encodeMessagePacket(t.rng[], t.codec, toId, toAddr,
     message)
   t.sendToA(toAddr, data)
 
@@ -73,7 +73,7 @@ proc registerRequest(t: Transport, n: Node, message: seq[byte],
 proc sendMessage*(t: Transport, toNode: Node, message: seq[byte]) =
   doAssert(toNode.address.isSome())
   let address = toNode.address.get()
-  let (data, nonce) = encodeMessagePacket(t.rng[], t.codec,
+  let (data, nonce, haskey) = encodeMessagePacket(t.rng[], t.codec,
     toNode.id, address, message)
 
   t.registerRequest(toNode, message, nonce)

--- a/tests/discv5/test_discoveryv5.nim
+++ b/tests/discv5/test_discoveryv5.nim
@@ -629,7 +629,7 @@ suite "Discovery v5 Tests":
         sendNode = newNode(enrRec).expect("Properly initialized record")
       var codec = Codec(localNode: sendNode, privKey: privKey, sessions: Sessions.init(5))
 
-      let (packet, _) = encodeMessagePacket(rng[], codec,
+      let (packet, _, _) = encodeMessagePacket(rng[], codec,
         receiveNode.localNode.id, receiveNode.localNode.address.get(), @[])
       receiveNode.transport.receive(a, packet)
 
@@ -659,7 +659,7 @@ suite "Discovery v5 Tests":
     var codec = Codec(localNode: sendNode, privKey: privKey, sessions: Sessions.init(5))
     for i in 0 ..< 5:
       let a = localAddress(20303 + i)
-      let (packet, _) = encodeMessagePacket(rng[], codec,
+      let (packet, _, _) = encodeMessagePacket(rng[], codec,
         receiveNode.localNode.id, receiveNode.localNode.address.get(), @[])
       receiveNode.transport.receive(a, packet)
 
@@ -691,7 +691,7 @@ suite "Discovery v5 Tests":
 
     var firstRequestNonce: AESGCMNonce
     for i in 0 ..< 5:
-      let (packet, requestNonce) = encodeMessagePacket(rng[], codec,
+      let (packet, requestNonce, _) = encodeMessagePacket(rng[], codec,
         receiveNode.localNode.id, receiveNode.localNode.address.get(), @[])
       receiveNode.transport.receive(a, packet)
       if i == 0:

--- a/tests/discv5/test_discoveryv5_encoding.nim
+++ b/tests/discv5/test_discoveryv5_encoding.nim
@@ -526,7 +526,7 @@ suite "Discovery v5.1 Additional Encode/Decode":
       reqId = RequestId.init(rng[])
       message = encodeMessage(m, reqId)
 
-    let (data, nonce) = encodeMessagePacket(rng[], codecA, nodeB.id,
+    let (data, nonce, _) = encodeMessagePacket(rng[], codecA, nodeB.id,
       nodeB.address.get(), message)
 
     let decoded = codecB.decodePacket(nodeA.address.get(), data)
@@ -642,7 +642,7 @@ suite "Discovery v5.1 Additional Encode/Decode":
     codecB.sessions.store(nodeA.id, nodeA.address.get(), secrets.initiatorKey,
       secrets.recipientKey)
 
-    let (data, nonce) = encodeMessagePacket(rng[], codecA, nodeB.id,
+    let (data, nonce, _) = encodeMessagePacket(rng[], codecA, nodeB.id,
       nodeB.address.get(), message)
 
     let decoded = codecB.decodePacket(nodeA.address.get(), data)


### PR DESCRIPTION
When there is no valid key for a target, a random message is sent to trigger a Whoareyou,
and the message is stored to be sent in the Handshake message once keys are negotiated.

It does not make sense to repeat this with more messages if more request are to be sent almost
contemporarily. Even worse, this was triggering new Whoareyou messages, invalidating the previous
challenge. 

Better, we queue these messages and release them once keys had been negotiated.