### PR TITLE
Fix: arrive to working keys in case of simultaneous cross connect

### DIFF
--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -206,7 +206,6 @@ proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
           node.seen = true
           if t.client.addNode(node):
             trace "Added new node to routing table after handshake", node, tablesize=t.client.nodesDiscovered()
-          discard t.sendPending(node)
   else:
     trace "Packet decoding error", myport = t.bindAddress.port, error = decoded.error, address = a
 

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -206,8 +206,6 @@ proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
           node.seen = true
           if t.client.addNode(node):
             trace "Added new node to routing table after handshake", node, tablesize=t.client.nodesDiscovered()
-          # handshake finished, TODO: should this be inside the if above?
-          t.keyexchangeInProgress.excl(node.id)
           discard t.sendPending(node)
   else:
     trace "Packet decoding error", myport = t.bindAddress.port, error = decoded.error, address = a

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -124,8 +124,7 @@ proc sendWhoareyou(t: Transport, toId: NodeId, a: Address,
     t.sendToA(a, data)
   else:
     # TODO: is this reasonable to drop it? Should we allow a mini-queue here?
-    # Queue should be on sender side, as this is random encoded!
-    debug "Node with this id already has ongoing handshake, queuing packet", myport = t.bindAddress.port , dstId = toId, address = a
+    debug "Node with this id already has ongoing handshake, ignoring packet", myport = t.bindAddress.port , dstId = toId, address = a
 
 proc sendPending(t:Transport, toNode: Node):
       Future[void] {.async.} =


### PR DESCRIPTION
Once in a while, two nodes try to connect to each other almost at the same time. When this
happens, both sends a random message to the other, and then both receive this and responds
with a Whoareyou. They might notice that there is a cross-connect scenario, but still it is not easy to
decide which keys should be used. There are various scenarios depending on timing and on which
UDP messages get lost.

After receiving the Whoareyou message, nodes have a keypair, and use this to encrypt the handshake
message. However, these are different on the two sides.
When receiving the Handshake, they get the keypair of the other side, but this is different from what they
have just used to encode their Handshake message. Thus, nodes might end up needing to use two different
decryption keys for messages.

This fix stores both of these two decryption keys, making sure each message can be decoded.
Only one encryption key is stored, since that's enough.