### PR TITLE
Fix name for nimble archive for OSX

### DIFF
--- a/.github/actions/install_nimble/action.yml
+++ b/.github/actions/install_nimble/action.yml
@@ -30,7 +30,7 @@ runs:
         fi
 
         if [[ '${{ inputs.os }}' == 'macos' ]]; then
-          OS=apple
+          OS=macosx
         else
           OS='${{ inputs.os }}'
         fi


### PR DESCRIPTION
The name for the nimble archive for OSX has changed sometime in the past and broke our CI. This update addresses that.