### PR TITLE
Feature FindNodeFast Result Limit

### DIFF
--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -338,7 +338,7 @@ proc handleFindNode(d: Protocol, fromId: NodeId, fromAddr: Address,
     # TODO: Still deduplicate also?
     if fn.distances.all(proc (x: uint16): bool = return x <= 256):
       d.sendNodes(fromId, fromAddr, reqId,
-        d.routingTable.neighboursAtDistances(fn.distances, seenOnly = true))
+        d.routingTable.neighboursAtDistances(fn.distances, seenOnly = true, k = FindNodeResultLimit))
     else:
       # At least one invalid distance, but the polite node we are, still respond
       # with empty nodes.
@@ -347,7 +347,7 @@ proc handleFindNode(d: Protocol, fromId: NodeId, fromAddr: Address,
 proc handleFindNodeFast(d: Protocol, fromId: NodeId, fromAddr: Address,
     fnf: FindNodeFastMessage, reqId: RequestId) =
   d.sendNodes(fromId, fromAddr, reqId,
-    d.routingTable.neighbours(fnf.target, seenOnly = true))
+    d.routingTable.neighbours(fnf.target, seenOnly = true, k = FindNodeResultLimit))
   # TODO: if known, maybe we should add exact target even if not yet "seen"
 
 proc handleTalkReq(d: Protocol, fromId: NodeId, fromAddr: Address,

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -117,6 +117,7 @@ const
   LookupRequestLimit = 3 ## Amount of distances requested in a single Findnode
   ## message for a lookup or query
   FindNodeResultLimit = 16 ## Maximum amount of SPRs in the total Nodes messages
+  FindNodeFastResultLimit = 6 ## Maximum amount of SPRs in response to findNodeFast
   ## that will be processed
   MaxNodesPerMessage = 3 ## Maximum amount of SPRs per individual Nodes message
   RefreshInterval = 5.minutes ## Interval of launching a random query to
@@ -347,7 +348,7 @@ proc handleFindNode(d: Protocol, fromId: NodeId, fromAddr: Address,
 proc handleFindNodeFast(d: Protocol, fromId: NodeId, fromAddr: Address,
     fnf: FindNodeFastMessage, reqId: RequestId) =
   d.sendNodes(fromId, fromAddr, reqId,
-    d.routingTable.neighbours(fnf.target, seenOnly = true, k = FindNodeResultLimit))
+    d.routingTable.neighbours(fnf.target, seenOnly = true, k = FindNodeFastResultLimit))
   # TODO: if known, maybe we should add exact target even if not yet "seen"
 
 proc handleTalkReq(d: Protocol, fromId: NodeId, fromAddr: Address,
@@ -568,7 +569,7 @@ proc findNodeFast*(d: Protocol, toNode: Node, target: NodeId):
   let nodes = await d.waitNodes(toNode, reqId)
 
   if nodes.isOk:
-    let res = verifyNodesRecords(nodes.get(), toNode, FindNodeResultLimit)
+    let res = verifyNodesRecords(nodes.get(), toNode, FindNodeFastResultLimit)
     d.routingTable.setJustSeen(toNode)
     return ok(res)
   else:


### PR DESCRIPTION
We do not need that many responses with FindNodeFast as with FindNode, since the
reposes can be ordered by distance. We can set a lower limit for these, making it fit into fewer UDP packets.

based on https://github.com/codex-storage/nim-codex-dht/pull/93, merge after that (please avoid squashing).

