### PR TITLE
Reduce timeouts

### DIFF
--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -127,7 +127,7 @@ const
   IpMajorityInterval = 5.minutes ## Interval for checking the latest IP:Port
   ## majority and updating this when SPR auto update is set.
   InitialLookups = 1 ## Amount of lookups done when populating the routing table
-  ResponseTimeout* = 4.seconds ## timeout for the response of a request-response
+  ResponseTimeout* = 1.seconds ## timeout for the response of a request-response
   MaxProvidersEntries* = 1_000_000 # one million records
   MaxProvidersPerEntry* = 20 # providers per entry
   ## call

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -15,9 +15,9 @@ import
   "."/[node, encoding, sessions]
 
 const
-  handshakeTimeout* = 2.seconds ## timeout for the reply on the
+  handshakeTimeout* = 500.milliseconds ## timeout for the reply on the
   ## whoareyou message
-  responseTimeout* = 4.seconds ## timeout for the response of a request-response
+  responseTimeout* = 1.seconds ## timeout for the response of a request-response
   ## call
 
 type
@@ -116,8 +116,7 @@ proc sendWhoareyou(t: Transport, toId: NodeId, a: Address,
     let data = encodeWhoareyouPacket(t.rng[], t.codec, toId, a, requestNonce,
       recordSeq, pubkey)
     sleepAsync(handshakeTimeout).addCallback() do(data: pointer):
-    # TODO: should we still provide cancellation in case handshake completes
-    # correctly?
+      # handshake key is popped in decodeHandshakePacket. if not yet popped by timeout:
       if t.codec.hasHandshake(key):
         debug "Handshake timeout", myport = t.bindAddress.port , dstId = toId, address = a
         t.codec.handshakes.del(key)

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -93,7 +93,7 @@ proc sendMessage*(t: Transport, toNode: Node, message: seq[byte]) =
       t.send(toNode, data)
       t.keyexchangeInProgress.incl(toNode.id)
       trace "keyexchangeInProgress added", myport = t.bindAddress.port , dstId = toNode
-      sleepAsync(responseTimeout).addCallback() do(data: pointer):
+      sleepAsync(handshakeTimeout).addCallback() do(data: pointer):
         t.keyexchangeInProgress.excl(toNode.id)
         trace "keyexchangeInProgress removed (timeout)", myport = t.bindAddress.port , dstId = toNode
     else:


### PR DESCRIPTION
We really don't need these timeouts for UDP exchanges to be 2 and 4 seconds.
Later we should tune it better based on measurements or estimates.
We should also check the relation between these three values.