### PR TITLE
Measure rtt, estimate bw, and log every 5 minutes

### DIFF
--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -1047,8 +1047,9 @@ proc debugPrintLoop(d: Protocol) {.async.} =
       debug "bucket", depth = b.getDepth,
             len = b.nodes.len, standby = b.replacementLen
       for n in b.nodes:
-        debug "node", n, rttMin = n.stats.rttMin.int, rttAvg = n.stats.rttAvg.int,
-              bwMaxMbps = (n.stats.bwMax / 1e6).round(3), bwAvgMbps = (n.stats.bwAvg / 1e6).round(3)
+        debug "node", n, rttMin = n.stats.rttMin.int, rttAvg = n.stats.rttAvg.int
+        # bandwidth estimates are based on limited information, so not logging it yet to avoid confusion
+        # trace "node", n, bwMaxMbps = (n.stats.bwMax / 1e6).round(3), bwAvgMbps = (n.stats.bwAvg / 1e6).round(3)
 
 func init*(
     T: type DiscoveryConfig,

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -524,9 +524,7 @@ proc waitNodes(d: Protocol, fromNode: Node, reqId: RequestId):
           let
             deltaT = Moment.now() - firstTime
             bwBps = 500.0 * 8.0 / (deltaT.nanoseconds.float / i.float / 1e9)
-          debug "bw estimate:", deltaT = deltaT, i,
-                bw_mbps = bwBps / 1e6,
-                node = fromNode
+          # trace "bw estimate:", deltaT = deltaT, i, bw_mbps = bwBps / 1e6, node = fromNode
           fromNode.registerBw(bwBps)
         else:
           # No error on this as we received some nodes.

--- a/codexdht/private/eth/p2p/discoveryv5/routing_table.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/routing_table.nim
@@ -180,6 +180,8 @@ proc midpoint(k: KBucket): NodeId =
 
 proc len(k: KBucket): int = k.nodes.len
 
+proc replacementLen*(k: KBucket): int = k.replacementCache.len
+
 proc tail(k: KBucket): Node = k.nodes[high(k.nodes)]
 
 proc ipLimitInc(r: var RoutingTable, b: KBucket, n: Node): bool =
@@ -280,6 +282,9 @@ proc computeSharedPrefixBits(nodes: openArray[NodeId]): int =
 
   # Reaching this would mean that all node ids are equal.
   doAssert(false, "Unable to calculate number of shared prefix bits")
+
+proc getDepth*(b: KBucket) : int =
+  computeSharedPrefixBits(@[b.istart, b.iend])
 
 proc init*(T: type RoutingTable, localNode: Node, bitsPerHop = DefaultBitsPerHop,
     ipLimits = DefaultTableIpLimits, rng: ref HmacDrbgContext,


### PR DESCRIPTION
Add measurement of RTT and a rough bandwidth estimate.
Log the content of the DHT routing table every 5 minutes.