### PR TITLE
fix: crash on logging 

### DIFF
--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -236,7 +236,7 @@ proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
             trace "Added new node to routing table after handshake", node, tablesize=t.client.nodesDiscovered()
           discard t.sendPending(node)
         else:
-          trace "address mismatch, not adding seen flag", node, address = a, nodeAddress = node.address.get()
+          trace "address mismatch, not adding seen flag", node, address = a, nodeAddress = node.address
   else:
     dht_transport_rx_packets.inc(labelValues = ["failed_decode"])
     dht_transport_rx_bytes.inc(packet.len.int64, labelValues = ["failed_decode"])


### PR DESCRIPTION
This PR fixes a crash discovered when running DHT experimentation regarding the UDP connections: 

```
  /home/arnaud/logos-storage-nim/storage.nim(153) storage                                                                                                                                     
  /home/arnaud/logos-storage-nim/vendor/nim-chronos/chronos/internal/asyncengine.nim(150) poll                                                                                                
  /home/arnaud/logos-storage-nim/vendor/nim-chronos/chronos/transports/datagram.nim(470) readDatagramLoop                                                                                     
  /home/arnaud/logos-storage-nim/vendor/nim-chronos/chronos/transports/datagram.nim(719) wrap                                                                                                 
  /home/arnaud/logos-storage-nim/vendor/nim-chronos/chronos/internal/asyncfutures.nim(371) futureContinue                                                                                     
  /home/arnaud/logos-storage-nim/vendor/nim-chronos/chronos/transports/datagram.nim(720) wrap                                                                                                 
  /home/arnaud/logos-storage-nim/vendor/logos-storage-nim-dht/codexdht/private/eth/p2p/discoveryv5/transport.nim(247) processClient                                                           
  /home/arnaud/logos-storage-nim/vendor/nim-chronos/chronos/internal/asyncfutures.nim(371) futureContinue                                                                                     
  /home/arnaud/logos-storage-nim/vendor/logos-storage-nim-dht/codexdht/private/eth/p2p/discoveryv5/transport.nim(263) processClient                                                           
  /home/arnaud/logos-storage-nim/vendor/logos-storage-nim-dht/codexdht/private/eth/p2p/discoveryv5/transport.nim(239) receive                                                                 
  /home/arnaud/logos-storage-nim/vendor/nimbus-build-system/vendor/Nim/lib/pure/options.nim(231) get                                                                                          
  Error: unhandled exception: Can't obtain a value from a `none` [UnpackDefect]       
```