### PR TITLE
feat: client mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        nim: [2.2.8]
+        nim: [2.2.10]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout

--- a/codexdht.nimble
+++ b/codexdht.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.6.2"
+version       = "0.6.3"
 author        = "Status Research & Development GmbH"
 description   = "DHT based on Eth discv5 implementation"
 license       = "MIT"

--- a/codexdht/private/eth/p2p/discoveryv5/messages.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/messages.nim
@@ -83,6 +83,7 @@ type
 
   Message* = object
     reqId*: RequestId
+    clientMode*: bool
     case kind*: MessageKind
     of ping:
       ping*: PingMessage

--- a/codexdht/private/eth/p2p/discoveryv5/messages_encoding.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/messages_encoding.nim
@@ -361,7 +361,7 @@ proc decodeMessage*(body: openArray[byte]): DecodeResult[Message] =
   if pb.getField(3, clientModeField).isErr:
     return err("Invalid clientMode field")
 
-  message.clientMode = clientModeField != 0
+  message.clientMode = clientModeField == 1
 
   case kind
   of unused: return err("Invalid message type")

--- a/codexdht/private/eth/p2p/discoveryv5/messages_encoding.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/messages_encoding.nim
@@ -312,7 +312,7 @@ proc encode*(msg: TalkRespMessage): seq[byte] =
   pb.finish()
   pb.buffer
 
-proc encodeMessage*[T: SomeMessage](p: T, reqId: RequestId): seq[byte] =
+proc encodeMessage*[T: SomeMessage](p: T, reqId: RequestId, clientMode: bool = false): seq[byte] =
   result = newSeqOfCap[byte](64)
   result.add(messageKind(T).ord)
 
@@ -324,6 +324,10 @@ proc encodeMessage*[T: SomeMessage](p: T, reqId: RequestId): seq[byte] =
   var pb = initProtoBuffer()
   pb.write(1, reqId)
   pb.write(2, encoded)
+
+  if clientMode:
+    pb.write(3, 1'u64)
+
   pb.finish()
   result.add(pb.buffer)
   trace "Encoded protobuf message", typ = $T
@@ -344,6 +348,7 @@ proc decodeMessage*(body: openArray[byte]): DecodeResult[Message] =
   var
     reqId: RequestId
     encoded: EncodedMessage
+    clientModeField: uint64
 
   if pb.getRequiredField(1, reqId).isErr:
     return err("Invalid request-id")
@@ -352,6 +357,11 @@ proc decodeMessage*(body: openArray[byte]): DecodeResult[Message] =
 
   if pb.getRequiredField(2, encoded).isErr:
     return err("Invalid message encoding")
+
+  if pb.getField(3, clientModeField).isErr:
+    return err("Invalid clientMode field")
+
+  message.clientMode = clientModeField != 0
 
   case kind
   of unused: return err("Invalid message type")

--- a/codexdht/private/eth/p2p/discoveryv5/messages_encoding.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/messages_encoding.nim
@@ -324,9 +324,7 @@ proc encodeMessage*[T: SomeMessage](p: T, reqId: RequestId, clientMode: bool = f
   var pb = initProtoBuffer()
   pb.write(1, reqId)
   pb.write(2, encoded)
-
-  if clientMode:
-    pb.write(3, 1'u64)
+  pb.write(3, clientMode.uint64)
 
   pb.finish()
   result.add(pb.buffer)

--- a/codexdht/private/eth/p2p/discoveryv5/messages_encoding.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/messages_encoding.nim
@@ -324,7 +324,7 @@ proc encodeMessage*[T: SomeMessage](p: T, reqId: RequestId, clientMode: bool = f
   var pb = initProtoBuffer()
   pb.write(1, reqId)
   pb.write(2, encoded)
-  pb.write(3, clientMode.uint64)
+  pb.write(3, clientMode.uint32)
 
   pb.finish()
   result.add(pb.buffer)
@@ -346,7 +346,7 @@ proc decodeMessage*(body: openArray[byte]): DecodeResult[Message] =
   var
     reqId: RequestId
     encoded: EncodedMessage
-    clientModeField: uint64
+    clientModeField: uint32
 
   if pb.getRequiredField(1, reqId).isErr:
     return err("Invalid request-id")

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -139,6 +139,13 @@ const
   NoreplyRemoveThreshold = 0.5 ## remove node on no reply if 'seen' is below this value
   clientModeProtocolId* = toBytes("clientMode") ## Protocol ID for clientMode check over TalkProtocol
 
+type DhtMode = enum
+  Server = 0.byte
+  Client = 1.byte
+
+func `==`(response: seq[byte], mode: DhtMode): bool =
+  response.len == 1 and response[0] == mode.byte
+
 func shortLog*(record: SignedPeerRecord): string =
   ## Returns compact string representation of ``SignedPeerRecord``.
   ##
@@ -182,7 +189,7 @@ type
     rng*: ref HmacDrbgContext
     providers: ProvidersManager
     clientMode*: bool
-    trackedFutures: seq[Future[bool]]
+    trackedFutures: Table[uint, Future[bool].Raising([CancelledError])]
 
   TalkProtocolHandler* = proc(p: TalkProtocol, request: seq[byte], fromId: NodeId, fromUdpAddress: Address): seq[byte]
     {.gcsafe, raises: [Defect].}
@@ -639,7 +646,7 @@ proc talkReq*(d: Protocol, toNode: Node, protocol, request: seq[byte]):
     dht_message_requests_outgoing.inc(labelValues = ["no_response"])
     return err("Talk response message not received in time")
 
-proc removeIfClientMode*(d: Protocol, node: Node): Future[bool] {.async.} =
+proc removeIfClientMode*(d: Protocol, node: Node): Future[bool] {.async: (raises: [CancelledError]).} =
   ## Remove node from routing table if it responds as a client.
   ## Returns true if the node was removed, false otherwise.
   ## The TalkProtocol is used because it is a plug and use solution.
@@ -649,11 +656,15 @@ proc removeIfClientMode*(d: Protocol, node: Node): Future[bool] {.async.} =
   ## it has to be propagated over the nodes.
   ## Note that if the talk protocol fails (timeout or error),
   ## the node is not removed in order to keep backward compatibility.
-  let resp = await d.talkReq(node, clientModeProtocolId, @[])
-  if resp.isOk() and resp.get() == @[byte 1]:
-    d.routingTable.removeNode(node)
-    return true
-  return false
+  try:
+    let resp = await d.talkReq(node, clientModeProtocolId, @[])
+    if resp.isOk() and resp.get() == DhtMode.Client:
+      d.routingTable.removeNode(node)
+      return true
+    return false
+  except CatchableError as e:
+    error "Failed to get the TalkProtocol response when checking the client mode", error = e.msg
+    return false
 
 proc lookupDistances*(target, dest: NodeId): seq[uint16] =
   let td = logDistance(target, dest)
@@ -685,11 +696,11 @@ proc lookupWorker(d: Protocol, destNode: Node, target: NodeId, fast: bool):
     # Attempt to add all nodes discovered
     for n in result:
       if d.addNode(n):
-        let fut = d.removeIfClientMode(n)
+        let fut: Future[bool].Raising([CancelledError]) = d.removeIfClientMode(n)
         fut.addCallback(proc(data: pointer) =
-          d.trackedFutures.remove(fut)
+          d.trackedFutures.del(fut.id)
         )
-        d.trackedFutures.add(fut)
+        d.trackedFutures[fut.id] = fut
 
 proc lookup*(d: Protocol, target: NodeId, fast: bool = false): Future[seq[Node]] {.async.} =
   ## Perform a lookup for the given target, return the closest n nodes to the
@@ -1226,7 +1237,7 @@ proc open*(d: Protocol) {.raises: [Defect, CatchableError].} =
       else:
         @[byte 0]
   )
-  discard d.registerTalkProtocol(clientModeProtocolId, clientModeProtocol).expect(
+  d.registerTalkProtocol(clientModeProtocolId, clientModeProtocol).expect(
     "Only one protocol should have this id"
   )
 
@@ -1253,6 +1264,10 @@ proc closeWait*(d: Protocol) {.async.} =
   if not d.ipMajorityLoop.isNil:
     await d.ipMajorityLoop.cancelAndWait()
 
-  d.trackedFutures.cancelTracked()
+  let cancellations = d.trackedFutures.values.toSeq.mapIt(it.cancelAndWait())
+  await noCancel allFutures cancellations
+  d.trackedFutures.clear()
+
+  d.talkProtocols.del(clientModeProtocolId)
 
   await d.transport.closeWait()

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -1233,9 +1233,9 @@ proc open*(d: Protocol) {.raises: [Defect, CatchableError].} =
     protocolHandler: proc(p: TalkProtocol, request: seq[byte], fromId: NodeId,
         fromUdpAddress: Address): seq[byte] {.raises: [].} =
       if d.clientMode:
-        @[byte 1]
+        @[DhtMode.Client.byte]
       else:
-        @[byte 0]
+        @[DhtMode.Server.byte]
   )
   d.registerTalkProtocol(clientModeProtocolId, clientModeProtocol).expect(
     "Only one protocol should have this id"

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -735,7 +735,7 @@ proc addProvider*(
 
   var res = await d.lookup(cId)
   # TODO: lookup is specified as not returning local, even if that is the closest. Is this OK?
-  if res.len == 0 and not d.clientMode:
+  if res.len == 0:
       res.add(d.localNode)
   for toNode in res:
     if toNode != d.localNode:

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -411,6 +411,13 @@ proc handleGetProviders(
 
 proc handleMessage(d: Protocol, srcId: NodeId, fromAddr: Address,
     message: Message) =
+
+  if message.clientMode:
+    let node = d.routingTable.getNode(srcId)
+    if node.isSome:
+      d.routingTable.removeNode(node.get)
+      trace "Node removed from routing table after handling message", srcId
+
   case message.kind
   of ping:
     dht_message_requests_incoming.inc()
@@ -444,12 +451,6 @@ proc handleMessage(d: Protocol, srcId: NodeId, fromAddr: Address,
       dht_unsolicited_messages.inc()
       trace "Timed out or unrequested message", kind = message.kind,
         origin = fromAddr
-
-  if message.clientMode:
-    let node = d.routingTable.getNode(srcId)
-    if node.isSome:
-      d.routingTable.removeNode(node.get)
-      trace "Node removed from routing table after handling message", srcId
 
 proc registerTalkProtocol*(d: Protocol, protocolId: seq[byte],
     protocol: TalkProtocol): DiscResult[void] =

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -685,7 +685,11 @@ proc lookupWorker(d: Protocol, destNode: Node, target: NodeId, fast: bool):
     # Attempt to add all nodes discovered
     for n in result:
       if d.addNode(n):
-        d.trackedFutures.add(d.removeIfClientMode(n))
+        let fut = d.removeIfClientMode(n)
+        fut.addCallback(proc(data: pointer) =
+          d.trackedFutures.remove(fut)
+        )
+        d.trackedFutures.add(fut)
 
 proc lookup*(d: Protocol, target: NodeId, fast: bool = false): Future[seq[Node]] {.async.} =
   ## Perform a lookup for the given target, return the closest n nodes to the
@@ -971,9 +975,6 @@ proc populateTable*(d: Protocol) {.async.} =
     total = d.routingTable.len()
 
 proc revalidateNode*(d: Protocol, n: Node) {.async.} =
-  # Prune completed futures to avoid unbounded growth
-  d.trackedFutures.keepItIf(not it.finished)
-
   let pong = await d.ping(n)
 
   if pong.isOk():
@@ -1252,8 +1253,6 @@ proc closeWait*(d: Protocol) {.async.} =
   if not d.ipMajorityLoop.isNil:
     await d.ipMajorityLoop.cancelAndWait()
 
-  for fut in d.trackedFutures:
-    if not fut.finished:
-      await fut.cancelAndWait()
+  d.trackedFutures.cancelTracked()
 
   await d.transport.closeWait()

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -449,6 +449,7 @@ proc handleMessage(d: Protocol, srcId: NodeId, fromAddr: Address,
     let node = d.routingTable.getNode(srcId)
     if node.isSome:
       d.routingTable.removeNode(node.get)
+      trace "Node removed from routing table after handling message", srcId
 
 proc registerTalkProtocol*(d: Protocol, protocolId: seq[byte],
     protocol: TalkProtocol): DiscResult[void] =

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -180,6 +180,7 @@ type
     talkProtocols*: Table[seq[byte], TalkProtocol] # TODO: Table is a bit of
     rng*: ref HmacDrbgContext
     providers: ProvidersManager
+    clientMode*: bool
 
   TalkProtocolHandler* = proc(p: TalkProtocol, request: seq[byte], fromId: NodeId, fromUdpAddress: Address): seq[byte]
     {.gcsafe, raises: [Defect].}
@@ -340,10 +341,13 @@ proc handleFindNode(d: Protocol, fromId: NodeId, fromAddr: Address,
   if fn.distances.len == 0:
     d.sendNodes(fromId, fromAddr, reqId, [])
   elif fn.distances.contains(0):
-    # A request for our own record.
-    # It would be a weird request if there are more distances next to 0
-    # requested, so in this case lets just pass only our own. TODO: OK?
-    d.sendNodes(fromId, fromAddr, reqId, [d.localNode])
+    if d.clientMode:
+      d.sendNodes(fromId, fromAddr, reqId, [])
+    else:
+      # A request for our own record.
+      # It would be a weird request if there are more distances next to 0
+      # requested, so in this case lets just pass only our own. TODO: OK?
+      d.sendNodes(fromId, fromAddr, reqId, [d.localNode])
   else:
     # TODO: Still deduplicate also?
     if fn.distances.all(proc (x: uint16): bool = return x <= 256):
@@ -731,7 +735,7 @@ proc addProvider*(
 
   var res = await d.lookup(cId)
   # TODO: lookup is specified as not returning local, even if that is the closest. Is this OK?
-  if res.len == 0:
+  if res.len == 0 and not d.clientMode:
       res.add(d.localNode)
   for toNode in res:
     if toNode != d.localNode:

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -986,8 +986,7 @@ proc revalidateNode*(d: Protocol, n: Node) {.async.} =
       # Request new SPR
       let nodes = await d.findNode(n, @[0'u16])
       if nodes.isOk() and nodes[].len > 0:
-        if d.addNode(nodes[][0]):
-          d.trackedFutures.add(d.removeIfClientMode(nodes[][0]))
+        discard d.addNode(nodes[][0])
 
     # Get IP and port from pong message and add it to the ip votes
     trace "pong rx", n, myip = res.ip, myport = res.port

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -76,7 +76,7 @@
 import
   std/[net, tables, sets, options, math, sequtils, algorithm, strutils],
   json_serialization/std/net,
-  stew/[base64, byteutils, endians2],
+  stew/[base64, endians2],
   pkg/[chronicles, chronicles/chronos_tools],
   pkg/chronos,
   pkg/stint,
@@ -137,15 +137,6 @@ const
   LookupSeenThreshold = 0.0 ## threshold used for lookup nodeset selection
   QuerySeenThreshold = 0.0 ## threshold used for query nodeset selection
   NoreplyRemoveThreshold = 0.5 ## remove node on no reply if 'seen' is below this value
-  clientModeProtocolId* = toBytes("clientMode") ## Protocol ID for clientMode check over TalkProtocol
-
-type DhtMode = enum
-  Server = 0.byte
-  Client = 1.byte
-
-func `==`(response: seq[byte], mode: DhtMode): bool =
-  response.len == 1 and response[0] == mode.byte
-
 func shortLog*(record: SignedPeerRecord): string =
   ## Returns compact string representation of ``SignedPeerRecord``.
   ##
@@ -189,7 +180,6 @@ type
     rng*: ref HmacDrbgContext
     providers: ProvidersManager
     clientMode*: bool
-    trackedFutures: Table[uint, Future[bool].Raising([CancelledError])]
 
   TalkProtocolHandler* = proc(p: TalkProtocol, request: seq[byte], fromId: NodeId, fromUdpAddress: Address): seq[byte]
     {.gcsafe, raises: [Defect].}
@@ -307,7 +297,7 @@ proc updateRecord*(
 proc sendResponse(d: Protocol, dstId: NodeId, dstAddr: Address,
     message: SomeMessage, reqId: RequestId) =
   ## send Response using the specifid reqId
-  d.transport.sendMessage(dstId, dstAddr, encodeMessage(message, reqId))
+  d.transport.sendMessage(dstId, dstAddr, encodeMessage(message, reqId, d.clientMode))
 
 proc sendNodes(d: Protocol, toId: NodeId, toAddr: Address, reqId: RequestId,
     nodes: openArray[Node]) =
@@ -455,6 +445,11 @@ proc handleMessage(d: Protocol, srcId: NodeId, fromAddr: Address,
       trace "Timed out or unrequested message", kind = message.kind,
         origin = fromAddr
 
+  if message.clientMode:
+    let node = d.routingTable.getNode(srcId)
+    if node.isSome:
+      d.routingTable.removeNode(node.get)
+
 proc registerTalkProtocol*(d: Protocol, protocolId: seq[byte],
     protocol: TalkProtocol): DiscResult[void] =
   # Currently allow only for one handler per talk protocol.
@@ -476,7 +471,7 @@ proc sendRequest*[T: SomeMessage](d: Protocol, toNode: Node, m: T,
     reqId: RequestId) =
   doAssert(toNode.address.isSome())
   let
-    message = encodeMessage(m, reqId)
+    message = encodeMessage(m, reqId, d.clientMode)
 
   trace "Send message packet", dstId = toNode.id,
     address = toNode.address, kind = messageKind(T)
@@ -646,26 +641,6 @@ proc talkReq*(d: Protocol, toNode: Node, protocol, request: seq[byte]):
     dht_message_requests_outgoing.inc(labelValues = ["no_response"])
     return err("Talk response message not received in time")
 
-proc removeIfClientMode*(d: Protocol, node: Node): Future[bool] {.async: (raises: [CancelledError]).} =
-  ## Remove node from routing table if it responds as a client.
-  ## Returns true if the node was removed, false otherwise.
-  ## The TalkProtocol is used because it is a plug and use solution.
-  ## Another solution would be to include clientMode in the SPR,
-  ## but it would change every time the clientMode is updated
-  ## and it is not really compatible with mode changes because
-  ## it has to be propagated over the nodes.
-  ## Note that if the talk protocol fails (timeout or error),
-  ## the node is not removed in order to keep backward compatibility.
-  try:
-    let resp = await d.talkReq(node, clientModeProtocolId, @[])
-    if resp.isOk() and resp.get() == DhtMode.Client:
-      d.routingTable.removeNode(node)
-      return true
-    return false
-  except CatchableError as e:
-    error "Failed to get the TalkProtocol response when checking the client mode", error = e.msg
-    return false
-
 proc lookupDistances*(target, dest: NodeId): seq[uint16] =
   let td = logDistance(target, dest)
   let tdAsInt = int(td)
@@ -695,12 +670,7 @@ proc lookupWorker(d: Protocol, destNode: Node, target: NodeId, fast: bool):
 
     # Attempt to add all nodes discovered
     for n in result:
-      if d.addNode(n):
-        let fut: Future[bool].Raising([CancelledError]) = d.removeIfClientMode(n)
-        fut.addCallback(proc(data: pointer) =
-          d.trackedFutures.del(fut.id)
-        )
-        d.trackedFutures[fut.id] = fut
+      discard d.addNode(n)
 
 proc lookup*(d: Protocol, target: NodeId, fast: bool = false): Future[seq[Node]] {.async.} =
   ## Perform a lookup for the given target, return the closest n nodes to the
@@ -989,10 +959,6 @@ proc revalidateNode*(d: Protocol, n: Node) {.async.} =
   let pong = await d.ping(n)
 
   if pong.isOk():
-    if await d.removeIfClientMode(n):
-      debug "Removed client mode node from routing table", node = n
-      return
-
     let res = pong.get()
     if res.sprSeq > n.record.seqNum:
       # Request new SPR
@@ -1229,18 +1195,6 @@ proc open*(d: Protocol) {.raises: [Defect, CatchableError].} =
   d.transport.open()
   trace "Transport open."
 
-  let clientModeProtocol = TalkProtocol(
-    protocolHandler: proc(p: TalkProtocol, request: seq[byte], fromId: NodeId,
-        fromUdpAddress: Address): seq[byte] {.raises: [].} =
-      if d.clientMode:
-        @[DhtMode.Client.byte]
-      else:
-        @[DhtMode.Server.byte]
-  )
-  d.registerTalkProtocol(clientModeProtocolId, clientModeProtocol).expect(
-    "Only one protocol should have this id"
-  )
-
   d.seedTable()
   trace "Routing table seeded."
 
@@ -1263,11 +1217,5 @@ proc closeWait*(d: Protocol) {.async.} =
     await d.refreshLoop.cancelAndWait()
   if not d.ipMajorityLoop.isNil:
     await d.ipMajorityLoop.cancelAndWait()
-
-  let cancellations = d.trackedFutures.values.toSeq.mapIt(it.cancelAndWait())
-  await noCancel allFutures cancellations
-  d.trackedFutures.clear()
-
-  d.talkProtocols.del(clientModeProtocolId)
 
   await d.transport.closeWait()

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -1225,7 +1225,9 @@ proc open*(d: Protocol) {.raises: [Defect, CatchableError].} =
       else:
         @[byte 0]
   )
-  discard d.registerTalkProtocol(clientModeProtocolId, clientModeProtocol)
+  discard d.registerTalkProtocol(clientModeProtocolId, clientModeProtocol).expect(
+    "Only one protocol should have this id"
+  )
 
   d.seedTable()
   trace "Routing table seeded."

--- a/codexdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -76,7 +76,7 @@
 import
   std/[net, tables, sets, options, math, sequtils, algorithm, strutils],
   json_serialization/std/net,
-  stew/[base64, endians2],
+  stew/[base64, byteutils, endians2],
   pkg/[chronicles, chronicles/chronos_tools],
   pkg/chronos,
   pkg/stint,
@@ -137,6 +137,7 @@ const
   LookupSeenThreshold = 0.0 ## threshold used for lookup nodeset selection
   QuerySeenThreshold = 0.0 ## threshold used for query nodeset selection
   NoreplyRemoveThreshold = 0.5 ## remove node on no reply if 'seen' is below this value
+  clientModeProtocolId* = toBytes("clientMode") ## Protocol ID for clientMode check over TalkProtocol
 
 func shortLog*(record: SignedPeerRecord): string =
   ## Returns compact string representation of ``SignedPeerRecord``.
@@ -181,6 +182,7 @@ type
     rng*: ref HmacDrbgContext
     providers: ProvidersManager
     clientMode*: bool
+    trackedFutures: seq[Future[bool]]
 
   TalkProtocolHandler* = proc(p: TalkProtocol, request: seq[byte], fromId: NodeId, fromUdpAddress: Address): seq[byte]
     {.gcsafe, raises: [Defect].}
@@ -341,13 +343,10 @@ proc handleFindNode(d: Protocol, fromId: NodeId, fromAddr: Address,
   if fn.distances.len == 0:
     d.sendNodes(fromId, fromAddr, reqId, [])
   elif fn.distances.contains(0):
-    if d.clientMode:
-      d.sendNodes(fromId, fromAddr, reqId, [])
-    else:
-      # A request for our own record.
-      # It would be a weird request if there are more distances next to 0
-      # requested, so in this case lets just pass only our own. TODO: OK?
-      d.sendNodes(fromId, fromAddr, reqId, [d.localNode])
+    # A request for our own record.
+    # It would be a weird request if there are more distances next to 0
+    # requested, so in this case lets just pass only our own. TODO: OK?
+    d.sendNodes(fromId, fromAddr, reqId, [d.localNode])
   else:
     # TODO: Still deduplicate also?
     if fn.distances.all(proc (x: uint16): bool = return x <= 256):
@@ -640,6 +639,22 @@ proc talkReq*(d: Protocol, toNode: Node, protocol, request: seq[byte]):
     dht_message_requests_outgoing.inc(labelValues = ["no_response"])
     return err("Talk response message not received in time")
 
+proc removeIfClientMode*(d: Protocol, node: Node): Future[bool] {.async.} =
+  ## Remove node from routing table if it responds as a client.
+  ## Returns true if the node was removed, false otherwise.
+  ## The TalkProtocol is used because it is a plug and use solution.
+  ## Another solution would be to include clientMode in the SPR,
+  ## but it would change every time the clientMode is updated
+  ## and it is not really compatible with mode changes because
+  ## it has to be propagated over the nodes.
+  ## Note that if the talk protocol fails (timeout or error),
+  ## the node is not removed in order to keep backward compatibility.
+  let resp = await d.talkReq(node, clientModeProtocolId, @[])
+  if resp.isOk() and resp.get() == @[byte 1]:
+    d.routingTable.removeNode(node)
+    return true
+  return false
+
 proc lookupDistances*(target, dest: NodeId): seq[uint16] =
   let td = logDistance(target, dest)
   let tdAsInt = int(td)
@@ -669,7 +684,8 @@ proc lookupWorker(d: Protocol, destNode: Node, target: NodeId, fast: bool):
 
     # Attempt to add all nodes discovered
     for n in result:
-      discard d.addNode(n)
+      if d.addNode(n):
+        d.trackedFutures.add(d.removeIfClientMode(n))
 
 proc lookup*(d: Protocol, target: NodeId, fast: bool = false): Future[seq[Node]] {.async.} =
   ## Perform a lookup for the given target, return the closest n nodes to the
@@ -955,15 +971,23 @@ proc populateTable*(d: Protocol) {.async.} =
     total = d.routingTable.len()
 
 proc revalidateNode*(d: Protocol, n: Node) {.async.} =
+  # Prune completed futures to avoid unbounded growth
+  d.trackedFutures.keepItIf(not it.finished)
+
   let pong = await d.ping(n)
 
   if pong.isOk():
+    if await d.removeIfClientMode(n):
+      debug "Removed client mode node from routing table", node = n
+      return
+
     let res = pong.get()
     if res.sprSeq > n.record.seqNum:
       # Request new SPR
       let nodes = await d.findNode(n, @[0'u16])
       if nodes.isOk() and nodes[].len > 0:
-        discard d.addNode(nodes[][0])
+        if d.addNode(nodes[][0]):
+          d.trackedFutures.add(d.removeIfClientMode(nodes[][0]))
 
     # Get IP and port from pong message and add it to the ip votes
     trace "pong rx", n, myip = res.ip, myport = res.port
@@ -1194,6 +1218,16 @@ proc open*(d: Protocol) {.raises: [Defect, CatchableError].} =
   d.transport.open()
   trace "Transport open."
 
+  let clientModeProtocol = TalkProtocol(
+    protocolHandler: proc(p: TalkProtocol, request: seq[byte], fromId: NodeId,
+        fromUdpAddress: Address): seq[byte] {.raises: [].} =
+      if d.clientMode:
+        @[byte 1]
+      else:
+        @[byte 0]
+  )
+  discard d.registerTalkProtocol(clientModeProtocolId, clientModeProtocol)
+
   d.seedTable()
   trace "Routing table seeded."
 
@@ -1216,5 +1250,9 @@ proc closeWait*(d: Protocol) {.async.} =
     await d.refreshLoop.cancelAndWait()
   if not d.ipMajorityLoop.isNil:
     await d.ipMajorityLoop.cancelAndWait()
+
+  for fut in d.trackedFutures:
+    if not fut.finished:
+      await fut.cancelAndWait()
 
   await d.transport.closeWait()

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -238,7 +238,10 @@ proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
             # We keep adding the node in the line above in order to not break anything.
             # Then we remove the node if it using client mode.
             # The operation is async because the check is done over TalkProtocol.
-            t.client.trackedFutures.add(t.client.removeIfClientMode(node))
+            let fut = t.client.removeIfClientMode(node)
+            fut.addCallback(proc(data: pointer) =
+              t.client.trackedFutures.remove(fut))
+            t.client.trackedFutures.add(fut)
 
           discard t.sendPending(node)
         else:

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -240,8 +240,8 @@ proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
             # The operation is async because the check is done over TalkProtocol.
             let fut = t.client.removeIfClientMode(node)
             fut.addCallback(proc(data: pointer) =
-              t.client.trackedFutures.remove(fut))
-            t.client.trackedFutures.add(fut)
+              t.client.trackedFutures.del(fut.id))
+            t.client.trackedFutures[fut.id] = fut
 
           discard t.sendPending(node)
         else:

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -232,16 +232,11 @@ proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
           # sending the 'whoareyou' message to. In that case, we can set 'seen'
           # TODO: verify how this works with restrictive NAT and firewall scenarios.
           node.registerSeen()
-          if t.client.addNode(node):
-            trace "Added new node to routing table after handshake", node, tablesize=t.client.nodesDiscovered()
 
-            # We keep adding the node in the line above in order to not break anything.
-            # Then we remove the node if it using client mode.
-            # The operation is async because the check is done over TalkProtocol.
-            let fut = t.client.removeIfClientMode(node)
-            fut.addCallback(proc(data: pointer) =
-              t.client.trackedFutures.del(fut.id))
-            t.client.trackedFutures[fut.id] = fut
+          if packet.message.clientMode:
+            t.client.routingTable.removeNode(node)
+          else:
+            discard t.client.addNode(node)
 
           discard t.sendPending(node)
         else:

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -236,7 +236,8 @@ proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
           if packet.message.clientMode:
             t.client.routingTable.removeNode(node)
           else:
-            discard t.client.addNode(node)
+            if t.client.addNode(node):
+              trace "Added new node to routing table after handshake", node, tablesize=t.client.nodesDiscovered()
 
           discard t.sendPending(node)
         else:

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -235,6 +235,7 @@ proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
 
           if packet.message.clientMode:
             t.client.routingTable.removeNode(node)
+            trace "Removed node from the routing table after handshake", node, tablesize=t.client.nodesDiscovered()
           else:
             if t.client.addNode(node):
               trace "Added new node to routing table after handshake", node, tablesize=t.client.nodesDiscovered()

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -235,10 +235,10 @@ proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
           if t.client.addNode(node):
             trace "Added new node to routing table after handshake", node, tablesize=t.client.nodesDiscovered()
 
-          # We keep adding the node in the line above in order to not break anything.
-          # Then we remove the node if it using client mode.
-          # The operation is async because the check is done over TalkProtocol.
-          t.client.trackedFutures.add(t.client.removeIfClientMode(node))
+            # We keep adding the node in the line above in order to not break anything.
+            # Then we remove the node if it using client mode.
+            # The operation is async because the check is done over TalkProtocol.
+            t.client.trackedFutures.add(t.client.removeIfClientMode(node))
 
           discard t.sendPending(node)
         else:

--- a/codexdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/codexdht/private/eth/p2p/discoveryv5/transport.nim
@@ -234,6 +234,12 @@ proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
           node.registerSeen()
           if t.client.addNode(node):
             trace "Added new node to routing table after handshake", node, tablesize=t.client.nodesDiscovered()
+
+          # We keep adding the node in the line above in order to not break anything.
+          # Then we remove the node if it using client mode.
+          # The operation is async because the check is done over TalkProtocol.
+          t.client.trackedFutures.add(t.client.removeIfClientMode(node))
+
           discard t.sendPending(node)
         else:
           trace "address mismatch, not adding seen flag", node, address = a, nodeAddress = node.address

--- a/tests/discv5/test_discoveryv5.nim
+++ b/tests/discv5/test_discoveryv5.nim
@@ -778,34 +778,14 @@ suite "Discovery v5 Tests":
     await node1.closeWait()
     await node2.closeWait()
 
-  test "Client mode is detected over TalkProtocol when clientMode is explicitly set to true":
+  test "Node is added to routing table when clientMode is not enabled":
     let
-      clientNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20310))
-      serverNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20311))
+      node1 = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20310))
+      node2 = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20311))
 
-    clientNode.clientMode = true
+    discard await discv5_protocol.ping(node1, node2.localNode)
 
-    let response = await discv5_protocol.talkReq(
-      serverNode, clientNode.localNode, clientModeProtocolId, @[])
-
-    check:
-      response.isOk()
-      response.get() == @[byte 1]
-
-    await clientNode.closeWait()
-    await serverNode.closeWait()
-
-  test "Client mode is not decteted when clientMode is not set":
-    let
-      node1 = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20312))
-      node2 = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20313))
-
-    let response = await discv5_protocol.talkReq(
-      node1, node2.localNode, clientModeProtocolId, @[])
-
-    check:
-      response.isOk()
-      response.get() == @[byte 0]
+    check node2.routingTable.len() == 1
 
     await node1.closeWait()
     await node2.closeWait()
@@ -817,30 +797,44 @@ suite "Discovery v5 Tests":
 
     clientNode.clientMode = true
 
-    # Trigger the handshake
     discard await discv5_protocol.ping(clientNode, serverNode.localNode)
-
-    check serverNode.routingTable.len() == 1
-
-    # Wait for TalkProtocol response
-    await sleepAsync(300.milliseconds)
 
     check serverNode.routingTable.len() == 0
 
     await clientNode.closeWait()
     await serverNode.closeWait()
 
+  test "Node is removed from routing table when clientMode is enabled after session is established":
+    let
+      node1 = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20318))
+      node2 = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20319))
+
+    # Establish session: node1 is added to node2's routing table
+    discard await discv5_protocol.ping(node1, node2.localNode)
+    check node2.routingTable.len() == 1
+
+    # node1 switches to client mode
+    node1.clientMode = true
+
+    # Second ping uses the existing session (ordinary message, not handshake)
+    discard await discv5_protocol.ping(node1, node2.localNode)
+
+    check node2.routingTable.len() == 0
+
+    await node1.closeWait()
+    await node2.closeWait()
+
   test "Node is removed from routing table when clientMode is enabled during validation":
     let
       clientNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20316))
       serverNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20317))
 
-    clientNode.clientMode = true
-
     # Add client node directly to server routing table
     check serverNode.addNode(clientNode.localNode)
     
     check serverNode.routingTable.len() == 1
+
+    clientNode.clientMode = true
 
     await serverNode.revalidateNode(clientNode.localNode)
 

--- a/tests/discv5/test_discoveryv5.nim
+++ b/tests/discv5/test_discoveryv5.nim
@@ -778,35 +778,73 @@ suite "Discovery v5 Tests":
     await node1.closeWait()
     await node2.closeWait()
 
-  test "Client mode: findNode(distance=0) returns empty":
-    # In client mode, the node should not advertise itself when asked for its
-    # own record (distance=0), so it does not appear in other nodes' routing tables.
+  test "Client mode is detected over TalkProtocol when clientMode is explicitly set to true":
     let
       clientNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20310))
       serverNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20311))
 
     clientNode.clientMode = true
 
-    let response = await discv5_protocol.findNode(serverNode, clientNode.localNode, @[0'u16])
+    let response = await discv5_protocol.talkReq(
+      serverNode, clientNode.localNode, clientModeProtocolId, @[])
 
     check:
       response.isOk()
-      response[].len == 0
+      response.get() == @[byte 1]
 
     await clientNode.closeWait()
     await serverNode.closeWait()
 
-  test "Server mode: findNode(distance=0) returns own record":
+  test "Client mode is not decteted when clientMode is not set":
     let
       node1 = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20312))
       node2 = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20313))
 
-    let response = await discv5_protocol.findNode(node1, node2.localNode, @[0'u16])
+    let response = await discv5_protocol.talkReq(
+      node1, node2.localNode, clientModeProtocolId, @[])
 
     check:
       response.isOk()
-      response[].len == 1
-      response[][0].id == node2.localNode.id
+      response.get() == @[byte 0]
 
     await node1.closeWait()
     await node2.closeWait()
+
+  test "Node is removed from routing table when clientMode is enabled":
+    let
+      clientNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20314))
+      serverNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20315))
+
+    clientNode.clientMode = true
+
+    # Trigger the handshake
+    discard await discv5_protocol.ping(clientNode, serverNode.localNode)
+
+    check serverNode.routingTable.len() == 1
+
+    # Wait for TalkProtocol response
+    await sleepAsync(300.milliseconds)
+
+    check serverNode.routingTable.len() == 0
+
+    await clientNode.closeWait()
+    await serverNode.closeWait()
+
+  test "Node is removed from routing table when clientMode is enabled during validation":
+    let
+      clientNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20316))
+      serverNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20317))
+
+    clientNode.clientMode = true
+
+    # Add client node directly to server routing table
+    check serverNode.addNode(clientNode.localNode)
+    
+    check serverNode.routingTable.len() == 1
+
+    await serverNode.revalidateNode(clientNode.localNode)
+
+    check serverNode.routingTable.len() == 0
+
+    await clientNode.closeWait()
+    await serverNode.closeWait()

--- a/tests/discv5/test_discoveryv5.nim
+++ b/tests/discv5/test_discoveryv5.nim
@@ -777,3 +777,36 @@ suite "Discovery v5 Tests":
 
     await node1.closeWait()
     await node2.closeWait()
+
+  test "Client mode: findNode(distance=0) returns empty":
+    # In client mode, the node should not advertise itself when asked for its
+    # own record (distance=0), so it does not appear in other nodes' routing tables.
+    let
+      clientNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20310))
+      serverNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20311))
+
+    clientNode.clientMode = true
+
+    let response = await discv5_protocol.findNode(serverNode, clientNode.localNode, @[0'u16])
+
+    check:
+      response.isOk()
+      response[].len == 0
+
+    await clientNode.closeWait()
+    await serverNode.closeWait()
+
+  test "Server mode: findNode(distance=0) returns own record":
+    let
+      node1 = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20312))
+      node2 = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20313))
+
+    let response = await discv5_protocol.findNode(node1, node2.localNode, @[0'u16])
+
+    check:
+      response.isOk()
+      response[].len == 1
+      response[][0].id == node2.localNode.id
+
+    await node1.closeWait()
+    await node2.closeWait()

--- a/tests/discv5/test_discoveryv5.nim
+++ b/tests/discv5/test_discoveryv5.nim
@@ -790,7 +790,7 @@ suite "Discovery v5 Tests":
     await node1.closeWait()
     await node2.closeWait()
 
-  test "Node is removed from routing table when clientMode is enabled":
+  test "Node is not added to routing table when clientMode is enabled":
     let
       clientNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20314))
       serverNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20315))
@@ -809,14 +809,12 @@ suite "Discovery v5 Tests":
       node1 = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20318))
       node2 = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20319))
 
-    # Establish session: node1 is added to node2's routing table
     discard await discv5_protocol.ping(node1, node2.localNode)
+
     check node2.routingTable.len() == 1
 
-    # node1 switches to client mode
     node1.clientMode = true
 
-    # Second ping uses the existing session (ordinary message, not handshake)
     discard await discv5_protocol.ping(node1, node2.localNode)
 
     check node2.routingTable.len() == 0
@@ -824,12 +822,12 @@ suite "Discovery v5 Tests":
     await node1.closeWait()
     await node2.closeWait()
 
-  test "Node is removed from routing table when clientMode is enabled during validation":
+  test "Node is removed from routing table when clientMode is enabled during re-validation":
     let
       clientNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20316))
       serverNode = initDiscoveryNode(rng, PrivateKey.example(rng), localAddress(20317))
 
-    # Add client node directly to server routing table
+    # Add client node directly to routing table
     check serverNode.addNode(clientNode.localNode)
     
     check serverNode.routingTable.len() == 1

--- a/tests/discv5/test_discoveryv5_encoding.nim
+++ b/tests/discv5/test_discoveryv5_encoding.nim
@@ -22,7 +22,7 @@ suite "Discovery v5.1 Protocol Message Encodings":
       reqId = RequestId(id: @[1.byte])
 
     let encoded = encodeMessage(p, reqId)
-    check byteutils.toHex(encoded) == "010a010112020801"
+    check byteutils.toHex(encoded) == "010a0101120208011800"
 
     let decoded = decodeMessage(encoded)
     check decoded.isOk()
@@ -42,7 +42,7 @@ suite "Discovery v5.1 Protocol Message Encodings":
       reqId = RequestId(id: @[1.byte])
 
     let encoded = encodeMessage(p, reqId)
-    check byteutils.toHex(encoded) == "020a01011211080112090a010112047f0000011a021388"
+    check byteutils.toHex(encoded) == "020a01011211080112090a010112047f0000011a0213881800"
 
     let decoded = decodeMessage(encoded)
     check decoded.isOk()
@@ -62,7 +62,7 @@ suite "Discovery v5.1 Protocol Message Encodings":
       reqId = RequestId(id: @[1.byte])
 
     let encoded = encodeMessage(fn, reqId)
-    check byteutils.toHex(encoded) == "030a010112040a020100"
+    check byteutils.toHex(encoded) == "030a010112040a0201001800"
 
     let decoded = decodeMessage(encoded)
     check decoded.isOk()
@@ -80,7 +80,7 @@ suite "Discovery v5.1 Protocol Message Encodings":
       reqId = RequestId(id: @[1.byte])
 
     let encoded = encodeMessage(n, reqId)
-    check byteutils.toHex(encoded) == "040a010112020801"
+    check byteutils.toHex(encoded) == "040a0101120208011800"
 
     let decoded = decodeMessage(encoded)
     check decoded.isOk()
@@ -102,7 +102,7 @@ suite "Discovery v5.1 Protocol Message Encodings":
       reqId = RequestId(id: @[1.byte])
 
     let encoded = encodeMessage(n, reqId)
-    check byteutils.toHex(encoded) == "040a0101129f03080112cc010a250802122102339d487ed237392d83791950dc891f0636de698c1fa051ea01ae3fa58bd78580120203011a560a2700250802122102339d487ed237392d83791950dc891f0636de698c1fa051ea01ae3fa58bd78580109cfd8992061a0b0a090400000000910200011a0b0a090400000000910200021a0b0a090400000000910200032a4730450221008cc77fd265e33c955174b9f49628048b2d72a6395acb30f0ba9d90536fa1a5d502207fa8e5bab8e8ddee9884a8e244b0990228e3546b5a9b6848632abd924796e57612cb010a2508021221026beda5cfddf1cd89130e7b5bb6092bac23db4a044bf847328aa0310dd123a445120203011a560a27002508021221026beda5cfddf1cd89130e7b5bb6092bac23db4a044bf847328aa0310dd123a445109cfd8992061a0b0a090400000000910200011a0b0a090400000000910200021a0b0a090400000000910200032a46304402203d41b1a78c5e6d98c9b4f3fcb213dc16ae4de50a1c8715ab29c516afe6488b4e02205841d09e92b3d2f1ad72c7bc066e561dab57320886f3fbbf272d2cf1732ca259"
+    check byteutils.toHex(encoded) == "040a0101129f03080112cc010a250802122102339d487ed237392d83791950dc891f0636de698c1fa051ea01ae3fa58bd78580120203011a560a2700250802122102339d487ed237392d83791950dc891f0636de698c1fa051ea01ae3fa58bd78580109cfd8992061a0b0a090400000000910200011a0b0a090400000000910200021a0b0a090400000000910200032a4730450221008cc77fd265e33c955174b9f49628048b2d72a6395acb30f0ba9d90536fa1a5d502207fa8e5bab8e8ddee9884a8e244b0990228e3546b5a9b6848632abd924796e57612cb010a2508021221026beda5cfddf1cd89130e7b5bb6092bac23db4a044bf847328aa0310dd123a445120203011a560a27002508021221026beda5cfddf1cd89130e7b5bb6092bac23db4a044bf847328aa0310dd123a445109cfd8992061a0b0a090400000000910200011a0b0a090400000000910200021a0b0a090400000000910200032a46304402203d41b1a78c5e6d98c9b4f3fcb213dc16ae4de50a1c8715ab29c516afe6488b4e02205841d09e92b3d2f1ad72c7bc066e561dab57320886f3fbbf272d2cf1732ca2591800"
 
     let decoded = decodeMessage(encoded)
     check decoded.isOk()
@@ -122,7 +122,7 @@ suite "Discovery v5.1 Protocol Message Encodings":
       reqId = RequestId(id: @[1.byte])
 
     let encoded = encodeMessage(tr, reqId)
-    check byteutils.toHex(encoded) == "050a0101120a0a046563686f12026869"
+    check byteutils.toHex(encoded) == "050a0101120a0a046563686f120268691800"
 
     let decoded = decodeMessage(encoded)
     check decoded.isOk()
@@ -140,7 +140,7 @@ suite "Discovery v5.1 Protocol Message Encodings":
       reqId = RequestId(id: @[1.byte])
 
     let encoded = encodeMessage(tr, reqId)
-    check byteutils.toHex(encoded) == "060a0101120412026869"
+    check byteutils.toHex(encoded) == "060a01011204120268691800"
 
     let decoded = decodeMessage(encoded)
     check decoded.isOk()
@@ -158,7 +158,7 @@ suite "Discovery v5.1 Protocol Message Encodings":
       # 1 byte too large
       reqId = RequestId(id: @[0.byte, 1, 2, 3, 4, 5, 6, 7, 8])
     let encoded = encodeMessage(p, reqId)
-    check byteutils.toHex(encoded) == "010a0900010203040506070812020801"
+    check byteutils.toHex(encoded) == "010a09000102030405060708120208011800"
 
     let decoded = decodeMessage(encoded)
     check decoded.isErr()
@@ -186,11 +186,8 @@ suite "Discovery v5.1 Protocol Message Encodings":
     check decodedServer.get().clientMode == false
 
   test "Message without clientMode field decodes as server mode":
-    let
-      p = PingMessage(sprSeq: 1'u64)
-      reqId = RequestId(id: @[1.byte])
-      encoded = encodeMessage(p, reqId)
-      decoded = decodeMessage(encoded)
+    # "010a010112020801" is a ping from a legacy node (clientMode field)
+    let decoded = decodeMessage(hexToSeqByte("010a010112020801"))
     check decoded.isOk()
     check decoded.get().clientMode == false
 

--- a/tests/discv5/test_discoveryv5_encoding.nim
+++ b/tests/discv5/test_discoveryv5_encoding.nim
@@ -170,6 +170,30 @@ suite "Discovery v5.1 Protocol Message Encodings":
     let decoded = decodeMessage(hexToSeqByte(encodedPong))
     check decoded.isErr()
 
+  test "clientMode flag is correctly encoded and decoded":
+    let
+      p = PingMessage(sprSeq: 1'u64)
+      reqId = RequestId(id: @[1.byte])
+
+    let encodedClient = encodeMessage(p, reqId, clientMode = true)
+    let decodedClient = decodeMessage(encodedClient)
+    check decodedClient.isOk()
+    check decodedClient.get().clientMode == true
+
+    let encodedServer = encodeMessage(p, reqId, clientMode = false)
+    let decodedServer = decodeMessage(encodedServer)
+    check decodedServer.isOk()
+    check decodedServer.get().clientMode == false
+
+  test "Message without clientMode field decodes as server mode":
+    let
+      p = PingMessage(sprSeq: 1'u64)
+      reqId = RequestId(id: @[1.byte])
+      encoded = encodeMessage(p, reqId) # no clientMode field (legacy node)
+      decoded = decodeMessage(encoded)
+    check decoded.isOk()
+    check decoded.get().clientMode == false
+
 # According to test vectors:
 # https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire-test-vectors.md#cryptographic-primitives
 suite "Discovery v5.1 Cryptographic Primitives Test Vectors":

--- a/tests/discv5/test_discoveryv5_encoding.nim
+++ b/tests/discv5/test_discoveryv5_encoding.nim
@@ -189,7 +189,7 @@ suite "Discovery v5.1 Protocol Message Encodings":
     let
       p = PingMessage(sprSeq: 1'u64)
       reqId = RequestId(id: @[1.byte])
-      encoded = encodeMessage(p, reqId) # no clientMode field (legacy node)
+      encoded = encodeMessage(p, reqId)
       decoded = decodeMessage(encoded)
     check decoded.isOk()
     check decoded.get().clientMode == false


### PR DESCRIPTION
**Context**

The routing table is populated in different places:

1. During the [`handshake`](https://github.com/logos-storage/logos-storage-nim-dht/blob/c24955c442815001c676ef45a493af5249937001/codexdht/private/eth/p2p/discoveryv5/transport.nim#L235-L241), for the connected node
2. During a [`lookup`](https://github.com/logos-storage/logos-storage-nim-dht/blob/c24955c442815001c676ef45a493af5249937001/codexdht/private/eth/p2p/discoveryv5/protocol.nim#L687), when a node advertises a CID for example
3. During startup, in [`seedTable`](https://github.com/logos-storage/logos-storage-nim-dht/blob/c24955c442815001c676ef45a493af5249937001/codexdht/private/eth/p2p/discoveryv5/protocol.nim#L950)
4. In [`revalidateNode`](https://github.com/logos-storage/logos-storage-nim-dht/blob/c24955c442815001c676ef45a493af5249937001/codexdht/private/eth/p2p/discoveryv5/protocol.nim#L989), in the revalidate loop

When the node is not reachable, we want to avoid adding it to the routing table in order not to pollute it.
This is why a client mode is introduced: when it is enabled, the node should not be added to the routing table.

A solution could be to add the `clientMode` into the SPR and check if it is enabled before adding the node to the routing table. While it would be convenient, it brings 2 different problems:

1. The SPR will change every time the client mode changes
2. After a change, the SPR has to be propagated again, so `clientMode` is not really a hot switch

Moreover, another issue to take into consideration is that the [`revalidateLoop`](https://github.com/logos-storage/logos-storage-nim-dht/blob/c24955c442815001c676ef45a493af5249937001/codexdht/private/eth/p2p/discoveryv5/protocol.nim#L997) removes a node when the ping fails. The problem with that is a connection can be kept alive if it was initiated by the non-reachable node and was kept pinging before the UDP hole punching timeout. So you can have a ping working for a non-reachable node and the revalidate loop will not remove it from the routing table.

**Solution**

Add `clientMode` flag to the message envelope so unreachable nodes are excluded from the routing table
